### PR TITLE
Running dev_appserver.py through filename instead of dir name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var through = require('through2'),
-  path = require('path'),
   gutil = require('gulp-util'),
   spawn = require('child_process').spawn,
 
@@ -51,7 +50,7 @@ module.exports = function (action, args, params, gae_dir) {
   }
 
   function bufferContents(file, enc, cb) {
-    var appYamlPath = path.dirname(file.path),
+    var appYamlPath = file.path,
       shouldWait = false;
 
     if (action == 'dev_appserver.py') {


### PR DESCRIPTION
Hi,

In my gae project, we've some envs, such as: dev, hom, prd. So, when I ran gulp-dev, it runs dev_appserver in dir, without specifying a yaml file, I removed file.dirname. Now it possible to run any yaml filename, that in my case is app_dev.yaml.

Thx
